### PR TITLE
send a close msg with userId to '/sys/close' when websockets closed

### DIFF
--- a/lib/server/websockets.js
+++ b/lib/server/websockets.js
@@ -114,6 +114,9 @@ _.extend(WebSocketConnection.prototype, {
 
   // This forgets the socket and closes the connection
   close: function() {
+    // send a close message with userId to osc clients
+    connections.send(shared.closeAddress, [this.userId])
+
     // Free the `userId` for another connection
     idManager.free(this.userId)
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -45,6 +45,7 @@ exports.subscribeAddress = '/sys/subscribe'
 exports.subscribedAddress = '/sys/subscribed'
 exports.sendBlobAddress = '/sys/blob'
 exports.errorAddress = '/sys/error'
+exports.closeAddress = '/sys/close'
 
 /* -------------------- Namespace tree -------------------- */
 exports.createNsTree = function(meths) {


### PR DESCRIPTION
here is my use case, for every user connect I create a new synth, so when the user close the page, I want to free the synth

```
OSCdef(\close, { |args|
  var userID = args[1];
  var nodeID = ~userNodeDict.at(userID);

  s.sendMsg(\n_free, nodeID);

}, '/sys/close', nil, 9001);
```
