### PR TITLE
allow port 80 so that don't have to type the port

### DIFF
--- a/bin/rhizome/validate-config.js
+++ b/bin/rhizome/validate-config.js
@@ -139,7 +139,7 @@ module.exports = function(config, done) {
     {
       webPort: function(val) {
         expect(val).to.be.a('number')
-        expect(val).to.be.within(1025, 49150)
+        expect(val).to.equal(80) || expect(val).to.be.within(1025, 49150)
       },
 
       oscPort: function(val) {


### PR DESCRIPTION
Not sure this is nice,  if the webPort is `80` then the user shoud `sudo rhizome config.js`.

any idea?
