### PR TITLE
mocha/instanbul are devDeps, no need to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Rhizome feature list
 
 [example](https://github.com/sebpiq/rhizome/tree/master/examples/base) | [OSC API](#from-osc-client)
 
-**websocket support**. A websocket client is included with rhizome. It can be used in your web pages, and handles all the dirty bits of websocket communication : automatic reconnection and so on ... 
+**websocket support**. A websocket client is included with rhizome. It can be used in your web pages, and handles all the dirty bits of websocket communication : automatic reconnection and so on ...
 
 [example](https://github.com/sebpiq/rhizome/tree/master/examples/base) | [websocket client API](#from-websocket-client)
 
@@ -214,14 +214,7 @@ export DEBUG=rhizome*
 
 #### Running tests and code coverage
 
-You need to install *mocha* for running the tests and *istanbul* for the test coverage :
-
-```
-npm install -g mocha
-npm install -g istanbul
-```
-
-Then from the root folder of the project, run tests like so :
+From the root of the project:
 
 ```
 npm test

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
     "osc-min": "0.2.x"
   },
   "devDependencies": {
+    "istanbul": "^0.3.14",
     "mocha": "1.17.x",
-    "stats-lite": "1.0.x",
-    "rimraf": "2.2.x"
+    "rimraf": "2.2.x",
+    "stats-lite": "1.0.x"
   },
   "bin": {
     "rhizome": "./bin/rhizome.js",


### PR DESCRIPTION
Kind of a trivial PR, but I always try to avoid installing global tools so I figured I'd update the docs to reflect that.