### PR TITLE
Prevent ws 1.1.1 from breaking all browserify builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "rhizome": "./bin/rhizome.js",
     "rhizome-blobs": "./bin/rhizome-blobs.js"
   },
+  "browser": {
+    "ws": false
+  },
   "license": "GPL-3.0",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
ws removed the browser compatible implementation in https://github.com/websockets/ws/commit/e54d45fbab3b19c2940e9057ce1e7b8f105873e0, breaking all Rhizome browserify builds without a major version! Fortunately Rhizome does the window.WebSocket check itself already.